### PR TITLE
correctly detect https

### DIFF
--- a/src/media.vimeo.js
+++ b/src/media.vimeo.js
@@ -43,7 +43,7 @@ videojs.Vimeo = videojs.MediaTechController.extend({
     
     this.player_el_.insertBefore(this.el_, this.player_el_.firstChild);
     
-    this.baseUrl = ('https:' === document.location.protocol)? 'https://secure.vimeo.com/video/' : 'http://player.vimeo.com/video/';
+    this.baseUrl = '//player.vimeo.com/video/';
 
     this.vimeo = {};
     this.vimeoInfo = {};


### PR DESCRIPTION
location.protocol returns the scheme followed by a ':', per https://developer.mozilla.org/en-US/docs/Web/API/Location
