### PR TITLE
Fix HTTPS handling constructing baseUrl

### DIFF
--- a/src/media.vimeo.js
+++ b/src/media.vimeo.js
@@ -43,7 +43,7 @@ videojs.Vimeo = videojs.MediaTechController.extend({
     
     this.player_el_.insertBefore(this.el_, this.player_el_.firstChild);
     
-    this.baseUrl = (document.location.protocol == 'https')? 'https://secure.vimeo.com/video/' : 'http://player.vimeo.com/video/';
+    this.baseUrl = document.location.protocol + '//player.vimeo.com/video/';
 
     this.vimeo = {};
     this.vimeoInfo = {};


### PR DESCRIPTION
Construct baseUrl in protocol relative manner. e.g. 'https:'/'http:' +
'//player.vimeo.com/video'

http://vimeo.com/forums/feature_requests/topic:38866

http://vimeo.com/help/faq/sharing-videos/embedding-videos#can-i-embed-my-video-on-an-https-domain
