### PR TITLE
fix errors when unloading/reloading a video src

### DIFF
--- a/src/media.vimeo.js
+++ b/src/media.vimeo.js
@@ -73,6 +73,7 @@ videojs.Vimeo = videojs.MediaTechController.extend({
 });
 
 videojs.Vimeo.prototype.dispose = function(){
+  this.vimeo.removeEvent('ready');
   this.vimeo.api('unload');
   delete this.vimeo;
   this.el_.parentNode.removeChild(this.el_);
@@ -157,7 +158,7 @@ videojs.Vimeo.prototype.onReady = function(){
 };
 
 videojs.Vimeo.prototype.onLoad = function(){
-  if (this.vimeo.api) {
+  if (this.vimeo && this.vimeo.api) {
     this.vimeo.api('unload');
     delete this.vimeo;
   }


### PR DESCRIPTION
fix a problem when disposing then reloading the vimeo player, for example when using various player techs.
this fix ensure only the new `ready` event is fired
