### PR TITLE
requiring videojs with requirejs

### DIFF
--- a/src/Vimeo.js
+++ b/src/Vimeo.js
@@ -17,7 +17,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE. */
 (function (root, factory) {
   if(typeof define === 'function' && define.amd) {
-    define(['video.js'], function(videojs){
+    define(['videojs'], function(videojs){
       return (root.Vimeo = factory(videojs));
     });
   } else if(typeof module === 'object' && module.exports) {


### PR DESCRIPTION
I had a similar issue as stated in videojs/videojs-youtube#373. Vimeo.js cannot find the file video.js, and setting the path for "video.js" in my RequireJS config file does not make sense. The solution of that issue in videojs-youtube helps to solve this problem. 
